### PR TITLE
feat(osu-list): Add 5 new items and fix styling/spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ Neither of these are official, however many users have reported success with the
 | [OpenTabletDriver](https://github.com/OpenTabletDriver/OpenTabletDriver)             | Open source, cross-platform, user-mode tablet driver                                                     |
 | [gosumemory](https://github.com/l3lackShark/gosumemory)                              | Cross-Platform memory reader for osu!                                                                    |
 | [PMDF](https://github.com/Piotrekol/ProcessMemoryDataFinder)                         | Library for interacting with in-memory values, used for StreamCompanion                                  |
+| [wysi](https://wysi727.com/)                                                         | Open-source osu website alternative with player setup details.                                           |
 
 [//]: <> (Reference links sorted alphabetically)
 

--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ Neither of these are official, however many users have reported success with the
 | [gosumemory](https://github.com/l3lackShark/gosumemory)                              | Cross-Platform memory reader for osu!                                                                    |
 | [PMDF](https://github.com/Piotrekol/ProcessMemoryDataFinder)                         | Library for interacting with in-memory values, used for StreamCompanion                                  |
 | [wysi](https://wysi727.com/)                                                         | Open-source osu website alternative with player setup details.                                           |
+| [huismetbenen](https://pp.huismetbenen.nl/)                                          | Osu PP rankings alternatives supporting simulation of pp reworks.                                        |
 
 [//]: <> (Reference links sorted alphabetically)
 

--- a/README.md
+++ b/README.md
@@ -238,7 +238,6 @@ Neither of these are official, however many users have reported success with the
 | [osu! batch beatmap downloader](https://github.com/nzbasic/batch-beatmap-downloader) | Tool for easily downloading large amounts of osu! maps                                                   |
 | [FunOrange's osu!trainer](https://github.com/FunOrange/osu-trainer)                  | A tool that allows you to modify the difficulty of a beatmap very easily.                                |
 | [OpenTabletDriver](https://github.com/OpenTabletDriver/OpenTabletDriver)             | Open source, cross-platform, user-mode tablet driver                                                     |
-| [gosumemory](https://github.com/l3lackShark/gosumemory)                              | Cross-Platform memory reader for osu!                                                                    |
 | [PMDF](https://github.com/Piotrekol/ProcessMemoryDataFinder)                         | Library for interacting with in-memory values, used for StreamCompanion                                  |
 | [wysi](https://wysi727.com/)                                                         | Open-source osu website alternative with player setup details.                                           |
 | [huismetbenen](https://pp.huismetbenen.nl/)                                          | Osu PP rankings alternatives supporting simulation of pp reworks.                                        |

--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ servers*, but may be useful for practice, writing tools or other things.
 | [Beatconnect](https://beatconnect.io/) | Comprehensive beatmap mirror with API support |
 | [Nerinyan](https://nerinyan.moe/)      |                                               |
 | [osu.direct](https://osu.direct/home)  |                                               |
-| [Chimu](https://chimu.moe/)            |                                               |
 | [Mino](https://catboy.best/)           |                                               |
 
 ## Osu! chatbots

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Neither of these are official, however many users have reported success with the
 | [Image to Anchors](https://github.com/OliBomby/Image-to-Anchors)               | Tool for converting images to slider anchors for view in the osu! editor.                          |
 | [Mapperator](https://github.com/mappingtools/Mapperator)                       | Efficient beatmap pattern search and beatmap construction based on features like rhythm & distance |
 | [osu-collaboration-bot](https://github.com/mappingtools/osu-collaboration-bot) | A Discord bot meant to streamline the organisation of mapping collabs for osu!                     |
+| [beatmap-viewer-web](https://github.com/FukutoTojido/beatmap-viewer-web)       | Open-source browser-based beatmap viewer                                                           |
 
 ## Skins
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Neither of these are official, however many users have reported success with the
 | [gosumemory](https://github.com/l3lackShark/gosumemory)          | Cross-Platform memory reader for osu! featuring web-based & in-game pp counters. |
 | [Ronnia](https://ronnia.me/)                                     | Twitch bot for linking maps from Twitch to ingame chat                           |
 | [Danser][danser]                                                 | High fps video creation tool for osu! replays.                                   |
+| [tosu](https://tosu.app)                                         | Eponymous software for reading osu! memory, accounting for most of gosumemory's issues |
 
 ### Chat clients
 

--- a/README.md
+++ b/README.md
@@ -1,44 +1,47 @@
 # osu-list [![Support Server](https://img.shields.io/discord/211953616918020107.svg?color=7289da&label=Circle%20People&logo=discord&style=flat-square)](https://discord.gg/circlepeople)
 
-An awesome-style list of osu! projects built by the community. Circle People is not affiliated with & does not endorse any projects listed here.
+An awesome-style list of osu! projects built by the community. Circle People is not affiliated with & does not endorse
+any projects listed here.
 
 ## Table of Contents
 
-  * [Official osu! projects](#official-osu-projects)
-  * [Gameplay](#gameplay)
+* [Official osu! projects](#official-osu-projects)
+* [Gameplay](#gameplay)
     + [Other operating systems](#other-operating-systems-osu-stable-client)
     + [Alternative game clients](#alternative-game-clients)
     + [Rulesets](#rulesets)
     + [Beatmap mirrors](#beatmap-mirrors)
-  + [Chatbots](#osu-chatbots)
-      + [Discord](#discord-chatbots)
-      + [In-game](#in-game-chatbots)
+
++ [Chatbots](#osu-chatbots)
+    + [Discord](#discord-chatbots)
+    + [In-game](#in-game-chatbots)
     + [Streaming tools](#streaming-tools)
     + [Chat clients](#chat-clients)
     + [Userscripts](#userscripts)
     + [Collections](#collections)
-  * [Mapping](#mapping)
-  * [Skins](#skins)
+
+* [Mapping](#mapping)
+* [Skins](#skins)
     + [Skinning resources](#skinning-resources)
     + [Skin listing](#skin-listing)
     + [Skin tools](#skin-tools)
-  * [Development](#development)
+* [Development](#development)
     + [Documentation](#documentation)
     + [API libraries](#api-libraries)
     + [Utility libraries](#utility-libraries)
-  * [Other projects](#other-projects)
-  * [Contributing](#contributing)
-  * [Notice](#notice)
+* [Other projects](#other-projects)
+* [Contributing](#contributing)
+* [Notice](#notice)
 
 ## Official osu! projects
 
-###### These projects are built by the osu! team directly.  
+###### These projects are built by the osu! team directly.
 
 | URL                                                   | Description/Notes                                                                                    |
-| ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+|-------------------------------------------------------|------------------------------------------------------------------------------------------------------|
 | [osu!](https://osu.ppy.sh)                            | The official website for the rhythm game osu!.                                                       |
 | [osu!lazer](https://github.com/ppy/osu)               | osu!lazer source code, the next generation client for osu!                                           |
-| [osu!stream](https://osustream.com/)                  | An official port of osu! on iOS and Android devices from a past era.                                  |
+| [osu!stream](https://osustream.com/)                  | An official port of osu! on iOS and Android devices from a past era.                                 |
 | [osu!web](https://github.com/ppy/osu-web)             | osu!'s website source code                                                                           |
 | [osu!wiki](https://github.com/ppy/osu-wiki)           | The home of the community-managed wiki for osu!                                                      |
 | [osu!framework](https://github.com/ppy/osu-framework) | The framework that powers osu!, including features that can be used to make other games/applications |
@@ -57,10 +60,12 @@ Neither of these are official, however many users have reported success with the
 
 ### Alternative game clients
 
-###### These are game clients that *do not connect to osu! servers*, but may be useful for practice, writing tools or other things.
+###### These are game clients that *do not connect to osu!
+
+servers*, but may be useful for practice, writing tools or other things.
 
 | Client                                                    | Description                                                    |
-| --------------------------------------------------------- | -------------------------------------------------------------- |
+|-----------------------------------------------------------|----------------------------------------------------------------|
 | [opsu!](https://itdelatrisu.github.io/opsu/)              | An unofficial open-source osu! client written in Java          |
 | [McOsu](https://store.steampowered.com/app/607260/McOsu/) | An osu! client designed for practice, with VR support          |
 | [osu!droid](http://ops.dgsrz.com/)                        | An open-source fanmade client of osu! for the Android platform |
@@ -68,13 +73,13 @@ Neither of these are official, however many users have reported success with the
 ### Rulesets
 
 | URL                                                                      | Description/Notes                            |
-| ------------------------------------------------------------------------ | -------------------------------------------- |
+|--------------------------------------------------------------------------|----------------------------------------------|
 | [Custom ruleset directory](https://github.com/ppy/osu/discussions/13096) | Official directory for lazer custom rulesets |
 
 ### Beatmap mirrors
 
 | Mirror                                 | Description/Notes                             |
-| -------------------------------------- | --------------------------------------------- |
+|----------------------------------------|-----------------------------------------------|
 | [Beatconnect](https://beatconnect.io/) | Comprehensive beatmap mirror with API support |
 | [Nerinyan](https://nerinyan.moe/)      |                                               |
 | [osu.direct](https://osu.direct/home)  |                                               |
@@ -82,10 +87,11 @@ Neither of these are official, however many users have reported success with the
 | [Mino](https://catboy.best/)           |                                               |
 
 ## Osu! chatbots
+
 ### Discord chatbots
 
 | Bot                                                   | Description/Notes                                                     |
-| ----------------------------------------------------- | --------------------------------------------------------------------- |
+|-------------------------------------------------------|-----------------------------------------------------------------------|
 | [owo!](http://owo-bot.xyz/)                           | Popular osu! tracking and score bot                                   |
 | [Sunny][sunny]                                        | osu! bot with support for restricted users and osu! login             |
 | [Bathbot][bathbot]                                    | Feature-rich bot for osu!                                             |
@@ -98,7 +104,7 @@ Neither of these are official, however many users have reported success with the
 ### In-Game chatbots
 
 | Bot                                                         | Description/Notes                                       |
-| ----------------------------------------------------------- | ------------------------------------------------------- |
+|-------------------------------------------------------------|---------------------------------------------------------|
 | [Tillerino](https://github.com/Tillerino/Tillerinobot/wiki) | Bot for beatmap recommendations                         |
 | [Sombrax79](https://ost.sombrax79.org/commands)             | Bot for stamina training recommendations                |
 | [Elitebotix](https://osu.ppy.sh/users/31050083)             | A osu! bot focused around tournaments and analysis.     |
@@ -107,19 +113,19 @@ Neither of these are official, however many users have reported success with the
 ### Lobby chatbots
 
 | Bot                                                             | Description/Notes                                       |
-| --------------------------------------------------------------- | ------------------------------------------------------- |
+|-----------------------------------------------------------------|---------------------------------------------------------|
 | [AutoHost](https://osu.ppy.sh/users/8921697)                    | osu!'s official autohost bot.                           |
 | [osu-ahr](https://github.com/Meowhal/osu-ahr)                   | Auto Host Rotation bot for osu! multiplayer.            |
 | [script-chan](https://git.cartooncraft.fr/shARPII/script-chan/) | A bot used to create and handle matches/players easily. |
 
 ### Streaming tools
 
-| Tool                                                             | Description                                                                      |
-| ---------------------------------------------------------------- | -------------------------------------------------------------------------------- |
-| [StreamCompanion](https://github.com/Piotrekol/StreamCompanion/) | A tool for streamers featuring a PP counter, map overlays, and more!             |
-| [gosumemory](https://github.com/l3lackShark/gosumemory)          | Cross-Platform memory reader for osu! featuring web-based & in-game pp counters. |
-| [Ronnia](https://ronnia.me/)                                     | Twitch bot for linking maps from Twitch to ingame chat                           |
-| [Danser][danser]                                                 | High fps video creation tool for osu! replays.                                   |
+| Tool                                                             | Description                                                                            |
+|------------------------------------------------------------------|----------------------------------------------------------------------------------------|
+| [StreamCompanion](https://github.com/Piotrekol/StreamCompanion/) | A tool for streamers featuring a PP counter, map overlays, and more!                   |
+| [gosumemory](https://github.com/l3lackShark/gosumemory)          | Cross-Platform memory reader for osu! featuring web-based & in-game pp counters.       |
+| [Ronnia](https://ronnia.me/)                                     | Twitch bot for linking maps from Twitch to ingame chat                                 |
+| [Danser][danser]                                                 | High fps video creation tool for osu! replays.                                         |
 | [tosu](https://tosu.app)                                         | Eponymous software for reading osu! memory, accounting for most of gosumemory's issues |
 
 ### Chat clients
@@ -131,10 +137,11 @@ Neither of these are official, however many users have reported success with the
 - [osuplus](https://github.com/limjeck/osuplus) - _requires osu!APIv1 key_
 - [osu!web enhanced](https://osu.ppy.sh/community/forums/topics/1361818)
 - [osu!web color changer](https://osuck.link/color)
+
 ### Collections
 
 | URL                                                                 | Description                                                                 |
-| ------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+|---------------------------------------------------------------------|-----------------------------------------------------------------------------|
 | [CollectionManager](https://github.com/Piotrekol/CollectionManager) | An extensive tool for creating, editing, and exporting of osu! collections. |
 | [osuCollector!](https://osucollector.com/)                          | Explore curated beatmap collections from fellow players.                    |
 | [osu-pps](https://osu-pps.com/)                                     | A list of the most overweighted maps in osu!.                               |
@@ -144,7 +151,7 @@ Neither of these are official, however many users have reported success with the
 ![wip](https://img.shields.io/badge/note-Work%20in%20progress-yellow)
 
 | URL                                                                            | Description                                                                                        |
-| ------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------- |
+|--------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------|
 | [storybrew](https://github.com/Damnae/storybrew)                               | Storyboard generator for osu!                                                                      |
 | [Mapset Verifier](https://github.com/Naxesss/MapsetVerifier)                   | A desktop app which tests quantifyable issues in osu! beatmapsets.                                 |
 | [Mapping Tools](https://github.com/OliBomby/Mapping_Tools)                     | Tools for manipulating beatmaps                                                                    |
@@ -161,14 +168,13 @@ Neither of these are official, however many users have reported success with the
 ![wip](https://img.shields.io/badge/note-Work%20in%20progress-yellow)
 
 | URL                                   | Description                               |
-| ------------------------------------- | ----------------------------------------- |
+|---------------------------------------|-------------------------------------------|
 | [osuskinner](https://osuskinner.com/) | Online tool for skin mixing and creation. |
 
 ### Skin listing
 
-
 | URL                                                     | Description/Notes                                                  |
-| ------------------------------------------------------- | ------------------------------------------------------------------ |
+|---------------------------------------------------------|--------------------------------------------------------------------|
 | [Circle People](https://circlepeople.com)               | Skins from many top players featured on the channel.               |
 | [rudj skinhub](https://github.com/rudj-skinhub/woal)    | Collection of skin sources from many players                       |
 | [Skinship Compendium](https://compendium.skinship.xyz/) | A comprehensive archive of all completed skins from the osu!forum. |
@@ -178,15 +184,13 @@ Neither of these are official, however many users have reported success with the
 
 ![wip](https://img.shields.io/badge/note-Work%20in%20progress-yellow)
 
-| URL                                                       | Description/Notes                                                         |
-| --------------------------------------------------------- | ------------------------------------------------------------------------- |
-| [OsuSkinMixer](https://github.com/rednir/OsuSkinMixer)    | Mix and manage your osu! skins with ease!                                 |
-| [OsuSkinChecker](https://github.com/RoanH/osuSkinChecker) | Simple program to check if all the elements for an osu! skin are present. |
-
+| URL                                                               | Description/Notes                                                         |
+|-------------------------------------------------------------------|---------------------------------------------------------------------------|
+| [OsuSkinMixer](https://github.com/rednir/OsuSkinMixer)            | Mix and manage your osu! skins with ease!                                 |
+| [OsuSkinChecker](https://github.com/RoanH/osuSkinChecker)         | Simple program to check if all the elements for an osu! skin are present. |
 | [Osuck's skin.ini editor](https://skins.osuck.net/tools/skin.ini) | Create your skin.ini file via a web interface.                            |
 
 ## Development
-
 
 ### Documentation
 
@@ -198,7 +202,7 @@ Neither of these are official, however many users have reported success with the
 ###### ⚠ These libraries are maintained by the community, and may have minor differences from the official API. Your mileage may vary.
 
 | Library                                                                                | Language   | Description/Notes                                                                     |
-| -------------------------------------------------------------------------------------- | ---------- | ------------------------------------------------------------------------------------- |
+|----------------------------------------------------------------------------------------|------------|---------------------------------------------------------------------------------------|
 | [aiosu](https://github.com/niceaesth/aiosu)                                            | python     | Async Python library for everything osu! related                                      |
 | [ossapi](https://github.com/circleguard/ossapi)                                        | python     | A definitive python wrapper for the osu! api.                                         |
 | [osu-api-extended](https://github.com/cyperdark/osu-api-extended)                      | typescript | Package for advanced work with "osu" api                                              |
@@ -209,7 +213,7 @@ Neither of these are official, however many users have reported success with the
 ### Utility libraries
 
 | Library                                                              | Language   | Description/Notes                                                                        |
-| -------------------------------------------------------------------- | ---------- | ---------------------------------------------------------------------------------------- |
+|----------------------------------------------------------------------|------------|------------------------------------------------------------------------------------------|
 | [rosu-pp](https://github.com/MaxOhn/rosu-pp)                         | rust       | Standalone crate to calculate star ratings and performance points for all osu! gamemodes |
 | [osu-classes](https://github.com/kionell/osu-classes)                | typescript | Rewrite of the basic class structure of osu!lazer in TypeScript                          |
 | [osu-parsers](https://github.com/kionell/osu-parsers)                | typescript | A bundle of TS parsers for all osu! data formats                                         |
@@ -228,7 +232,7 @@ Neither of these are official, however many users have reported success with the
 ## Other projects
 
 | URL                                                                                  | Description/Notes                                                                                        |
-| ------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------- |
+|--------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------|
 | [osu! matchmaking](https://oma.hwc.hr/)                                              | Competitive matchmaking system for osu!                                                                  |
 | [osumapper](https://github.com/kotritrona/osumapper)                                 | An automatic beatmap generator using Tensorflow / Deep Learning.                                         |
 | [Osekai.net](https://osekai.net/home/)                                               | the home of alternative rankings, in-depth profile info, medal solutions, hundreds of versions, and more |
@@ -245,8 +249,11 @@ Neither of these are official, however many users have reported success with the
 [//]: <> (Reference links sorted alphabetically)
 
 [bathbot]: https://discord.com/api/oauth2/authorize?client_id=297073686916366336&permissions=309238025216&scope=bot%20applications.commands
+
 [danser]: https://github.com/Wieku/danser-go
+
 [quna]: https://discord.com/api/oauth2/authorize?client_id=957969843343200276&permissions=2147863616&scope=applications.commands%20bot
+
 [sunny]: https://discord.com/oauth2/authorize?client_id=376679719044907019&scope=bot
 
 ---
@@ -266,14 +273,19 @@ Please follow these guidelines when adding a project:
 
 - Familiarize yourself with [Markdown](https://www.markdownguide.org/cheat-sheet/) so you don't break things.
 - This goes without saying, but it should be relevant to osu!.
-  - It also should not break osu! rules (ex. tools that give advantages that interact with the client, custom servers, etc.) If you don't know, ask.
+    - It also should not break osu! rules (ex. tools that give advantages that interact with the client, custom servers,
+      etc.) If you don't know, ask.
 - Provide some (concise) details about your project.
 - Avoid using link shorteners when possible.
-  - These are hard to moderate and deal with, hard links are appreciated (ex. A clean Discord invite link, a website, or a Git page for your bot)
-  - Long links can be dealt with by using [reference style links](https://www.markdownguide.org/basic-syntax/). This helps people using the web editor to help  readability.
-  - If you link to another project in the description that is already on this page, use a reference style link as well.
+    - These are hard to moderate and deal with, hard links are appreciated (ex. A clean Discord invite link, a website,
+      or a Git page for your bot)
+    - Long links can be dealt with by using [reference style links](https://www.markdownguide.org/basic-syntax/). This
+      helps people using the web editor to help readability.
+    - If you link to another project in the description that is already on this page, use a reference style link as
+      well.
 - When using the GitHub web editor use `No wrap` option so it doesn't look terrible when editing long tables.
 
 ## Notice
 
-This document is released under the CC BY-SA 4.0 license. "osu!" and "ppy" are trademarks of ppy Pty Ltd. & are not affiliated with Circle People.
+This document is released under the CC BY-SA 4.0 license. "osu!" and "ppy" are trademarks of ppy Pty Ltd. & are not
+affiliated with Circle People.

--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Neither of these are official, however many users have reported success with the
 | [OsuSkinMixer](https://github.com/rednir/OsuSkinMixer)    | Mix and manage your osu! skins with ease!                                 |
 | [OsuSkinChecker](https://github.com/RoanH/osuSkinChecker) | Simple program to check if all the elements for an osu! skin are present. |
 
+| [Osuck's skin.ini editor](https://skins.osuck.net/tools/skin.ini) | Create your skin.ini file via a web interface.                            |
 
 ## Development
 


### PR DESCRIPTION
## Adds the next resources:
- [osuck's skin.ini editor](https://skins.osuck.net/tools/skin.ini)
- [tosu](https://tosu.app)
- [huismetbenen](https://pp.huismetbenen.nl/)
- [wysi](https://wysi727.com/)
- [beatmap-viewer-web](https://github.com/FukutoTojido/beatmap-viewer-web)

## Other changes:
- Removal of `gosumemory` from `other projects` since it's already mentioned in `streaming tools`.
- Removal of `chimu.moe` from `beatmap mirrors` since it's been dead for the past 1 month and no signs of coming back.
- Styling & spacing fixes by default Jetbrains Intellij Idea formatter.